### PR TITLE
Updated JSFiddle url to use current scheme

### DIFF
--- a/index.haml
+++ b/index.haml
@@ -135,7 +135,7 @@
                 %use{xlink:href: "#download-icon"}
               Download .zip
 
-      %form#jsfiddle.settings{action: "http://jsfiddle.net/api/post/jquery/2/", method: "post", target: "check"}
+      %form#jsfiddle.settings{action: "//jsfiddle.net/api/post/jquery/2/", method: "post", target: "check"}
         .form-group.full
           %button.btn.edit-fidddle{type: "submit"}
             %svg.icon


### PR DESCRIPTION
The current url was sending over http even from https, triggering a security warning:
![Security warning on Firefox](https://cloud.githubusercontent.com/assets/1821404/14986028/781be41c-114a-11e6-9647-68d61e7ab782.png)

Fixed by using `//...` to select current scheme. 
